### PR TITLE
Fix tests with www.utoronto.ca

### DIFF
--- a/tests/102.phpt
+++ b/tests/102.phpt
@@ -12,7 +12,7 @@ var_dump(geoip_country_code_by_name(''));
 var_dump(geoip_country_code_by_name('127.0.0.1'));
 var_dump(geoip_country_code_by_name('localhost'));
 var_dump(geoip_country_code_by_name('128.100.132.238'));
-var_dump(geoip_country_code_by_name('www.utoronto.ca'));
+var_dump(geoip_country_code_by_name('utoronto.ca'));
 
 ?>
 --EXPECTF--

--- a/tests/103.phpt
+++ b/tests/103.phpt
@@ -12,7 +12,7 @@ var_dump(geoip_country_code3_by_name(''));
 var_dump(geoip_country_code3_by_name('127.0.0.1'));
 var_dump(geoip_country_code3_by_name('localhost'));
 var_dump(geoip_country_code3_by_name('128.100.132.238'));
-var_dump(geoip_country_code3_by_name('www.utoronto.ca'));
+var_dump(geoip_country_code3_by_name('utoronto.ca'));
 
 ?>
 --EXPECTF--

--- a/tests/104.phpt
+++ b/tests/104.phpt
@@ -12,7 +12,7 @@ var_dump(geoip_country_name_by_name(''));
 var_dump(geoip_country_name_by_name('127.0.0.1'));
 var_dump(geoip_country_name_by_name('localhost'));
 var_dump(geoip_country_name_by_name('128.100.132.238'));
-var_dump(geoip_country_name_by_name('www.utoronto.ca'));
+var_dump(geoip_country_name_by_name('utoronto.ca'));
 
 ?>
 --EXPECTF--

--- a/tests/107.phpt
+++ b/tests/107.phpt
@@ -12,7 +12,7 @@ var_dump(geoip_record_by_name(''));
 var_dump(geoip_record_by_name('127.0.0.1'));
 var_dump(geoip_record_by_name('localhost'));
 var_dump(geoip_record_by_name('128.100.132.238'));
-var_dump(geoip_record_by_name('www.utoronto.ca'));
+var_dump(geoip_record_by_name('utoronto.ca'));
 
 ?>
 --EXPECTF--


### PR DESCRIPTION
This pull request fixes several tests that failed due to www.utoronto.ca resolving to a US-based ip, it uses   utoronto.ca instead.